### PR TITLE
Thêm thread đọc dữ liệu serial và hiển thị có định dạng

### DIFF
--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -11,6 +11,8 @@
 #include <QSerialPortInfo>
 #include <QList>
 #include <QSerialPort>
+#include <QDateTime>
+#include "serialreader.h"
 
 // Namespace and class placeholders generated in ui_<classname>.h follow the naming conventions of your project.
 namespace Ui {
@@ -24,7 +26,8 @@ class MainWindow: public QMainWindow {
         Ui::MainWindow *ui; // Receive the ui pointer in ui_<classname>.h
         QSettings settings;
         QSerialPort serial;
-        
+        SerialReader *readerThread; ///< Thread lắng nghe dữ liệu.
+
         QString comPort;
         int baudrate;
         int parity;
@@ -45,6 +48,8 @@ class MainWindow: public QMainWindow {
         void loadSettings();
         void connectOrDisconnect();
         void sendData();
+        void handleReceivedData(const QString &data); ///< Xử lý dữ liệu nhận.
+        void appendMessage(const QString &prefix, const QString &data, const QString &color); ///< Hiển thị dữ liệu với màu.
 
     public:
         explicit MainWindow(QWidget *parent = nullptr);

--- a/ui/serialreader.cpp
+++ b/ui/serialreader.cpp
@@ -1,0 +1,43 @@
+#include "serialreader.h"
+#include <QByteArray>
+
+/**
+ * @brief Tạo mới đối tượng SerialReader.
+ * @param port QSerialPort* cổng serial cần lắng nghe.
+ * @param parent QObject* đối tượng cha.
+ */
+SerialReader::SerialReader(QSerialPort *port, QObject *parent)
+    : QThread(parent), m_port(port), m_running(false) {}
+
+/**
+ * @brief Yêu cầu dừng thread.
+ */
+void SerialReader::stop()
+{
+    m_running = false;
+}
+
+/**
+ * @brief Hàm thực thi chính của thread, đọc dữ liệu liên tục.
+ */
+void SerialReader::run()
+{
+    m_running = true;
+    while (m_running)
+    {
+        if (!m_port || !m_port->isOpen())
+        {
+            msleep(100);
+            continue;
+        }
+        if (m_port->waitForReadyRead(100))
+        {
+            QByteArray bytes = m_port->readAll();
+            if (!bytes.isEmpty())
+            {
+                QString data = QString::fromUtf8(bytes);
+                emit dataReceived(data);
+            }
+        }
+    }
+}

--- a/ui/serialreader.h
+++ b/ui/serialreader.h
@@ -1,0 +1,46 @@
+#ifndef SERIALREADER_H
+#define SERIALREADER_H
+
+#include <QThread>
+#include <QSerialPort>
+#include <QString>
+#include <atomic>
+
+/**
+ * @brief SerialReader đọc dữ liệu từ QSerialPort trong một thread riêng.
+ */
+class SerialReader : public QThread {
+    Q_OBJECT
+
+public:
+    /**
+     * @brief Khởi tạo SerialReader.
+     * @param port QSerialPort* cổng serial cần lắng nghe.
+     * @param parent QObject* đối tượng cha.
+     */
+    explicit SerialReader(QSerialPort *port, QObject *parent = nullptr);
+
+    /**
+     * @brief Dừng vòng lặp và kết thúc thread.
+     */
+    void stop();
+
+signals:
+    /**
+     * @brief Phát tín hiệu khi nhận được dữ liệu mới.
+     * @param data const QString& dữ liệu dạng chuỗi UTF-8.
+     */
+    void dataReceived(const QString &data);
+
+protected:
+    /**
+     * @brief Hàm được chạy khi thread bắt đầu, thực hiện vòng lặp chờ dữ liệu.
+     */
+    void run() override;
+
+private:
+    QSerialPort *m_port;              ///< Con trỏ tới QSerialPort đang được sử dụng.
+    std::atomic_bool m_running;       ///< Cờ điều khiển vòng lặp đọc dữ liệu.
+};
+
+#endif // SERIALREADER_H


### PR DESCRIPTION
## Tóm tắt
- Thêm lớp `SerialReader` dùng QThread để lắng nghe dữ liệu từ cổng serial.
- Hiển thị dữ liệu gửi/nhận kèm thời gian, dấu phân cách và màu sắc khác nhau.
- Dọn dẹp thread khi ngắt kết nối để tránh rò rỉ tài nguyên.

## Kiểm tra
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68bae9650a808322adb70fff7c3976d7