### PR TITLE
feat: clear context menu and autoscroll

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -1,4 +1,7 @@
 #include "mainwindow.h"
+#include <QMenu>
+#include <QAction>
+#include <QTextCursor>
 
 /**
  * @brief Khởi tạo MainWindow và thiết lập các kết nối tín hiệu.
@@ -78,8 +81,10 @@ void MainWindow::initializeInterface()
     QList<QString> popularNewLines = {"LF (\\n)", "CRLF (\\r\\n)", "CR (\\r)", "None"};
     ui->newLine->addItems(popularNewLines);
     
-    // Thiết lập QTextEdit để hiển thị HTML
+    // Thiết lập QTextEdit để hiển thị HTML và menu chuột phải
     ui->dataTransRecv->setAcceptRichText(true);
+    ui->dataTransRecv->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(ui->dataTransRecv, &QWidget::customContextMenuRequested, this, &MainWindow::showDataTransRecvContextMenu);
 }
 
 /**
@@ -290,6 +295,32 @@ void MainWindow::appendMessage(const QString &prefix, const QString &data, const
              prefix.toHtmlEscaped(),   // << sẽ thành &lt;&lt;
              data.toHtmlEscaped());    // bảo vệ mọi dấu <, &, "
     ui->dataTransRecv->append(html);
+    QTextCursor cursor = ui->dataTransRecv->textCursor();
+    cursor.movePosition(QTextCursor::End);
+    ui->dataTransRecv->setTextCursor(cursor);
+    ui->dataTransRecv->ensureCursorVisible();
+}
+
+/**
+ * @brief Hiển thị menu chuột phải cho vùng nhận dữ liệu.
+ * @param pos const QPoint& vị trí con trỏ chuột.
+ */
+void MainWindow::showDataTransRecvContextMenu(const QPoint &pos)
+{
+    QMenu *menu = ui->dataTransRecv->createStandardContextMenu();
+    menu->addSeparator();
+    QAction *clearAction = menu->addAction("Clear");
+    connect(clearAction, &QAction::triggered, this, &MainWindow::clearDataTransRecv);
+    menu->exec(ui->dataTransRecv->mapToGlobal(pos));
+    delete menu;
+}
+
+/**
+ * @brief Xóa toàn bộ nội dung trong ô hiển thị dữ liệu.
+ */
+void MainWindow::clearDataTransRecv()
+{
+    ui->dataTransRecv->clear();
 }
 
 /**

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -12,6 +12,7 @@
 #include <QList>
 #include <QSerialPort>
 #include <QDateTime>
+#include <QPoint>
 #include "../inc/serialreader.h"
 
 // Namespace and class placeholders generated in ui_<classname>.h follow the naming conventions of your project.
@@ -51,6 +52,8 @@ class MainWindow: public QMainWindow {
         void handleReceivedData(const QString &data); ///< Xử lý dữ liệu nhận.
         void appendMessage(const QString &prefix, const QString &data, const QString &color); ///< Hiển thị dữ liệu với màu.
         void updateSerialReaderNewLine(); ///< Cập nhật newline cho SerialReader.
+        void showDataTransRecvContextMenu(const QPoint &pos); ///< Hiển thị menu chuột phải.
+        void clearDataTransRecv(); ///< Xóa nội dung dataTransRecv.
 
     public:
         explicit MainWindow(QWidget *parent = nullptr);


### PR DESCRIPTION
## Summary
- Add custom context menu with Clear action for dataTransRecv
- Automatically scroll dataTransRecv to bottom on new data

## Testing
- `cmake .. && make -j$(nproc)` *(fails: Could not find a package configuration file provided by "Qt6" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1105c1188322903eea872b667cbb