### PR TITLE
Fix thread affinity warning for QSerialPort

### DIFF
--- a/src/serialreader.cpp
+++ b/src/serialreader.cpp
@@ -1,6 +1,7 @@
 #include "../inc/serialreader.h"
 #include <QDebug>
 #include <QMutexLocker>
+#include <QApplication>
 
 SerialReader::SerialReader(QSerialPort *serial, QObject *parent)
     : QThread(parent), m_serial(serial), m_stop(false)
@@ -72,5 +73,11 @@ void SerialReader::run()
     if (m_serial && m_serial->isOpen())
     {
         m_serial->close();
+    }
+
+    if (m_serial)
+    {
+        // Đưa QSerialPort trở lại thread chính để tránh cảnh báo.
+        m_serial->moveToThread(QApplication::instance()->thread());
     }
 }

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -334,7 +334,6 @@ void MainWindow::connectOrDisconnect()
         // Disconnect
         readerThread->stop();
         readerThread->wait();
-        serial.moveToThread(this->thread());
         delete readerThread;
         readerThread = nullptr;
         ui->connDisconnBtn->setText("Connect");


### PR DESCRIPTION
## Summary
- Remove moveToThread call from main thread when disconnecting
- Return QSerialPort to main thread within SerialReader to avoid QObject warning

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68bba329e0f88322b8711da64fc9bd56