### PR TITLE
Refactor baudrate selection and add clear option to log view

### DIFF
--- a/inc/SerialManager.h
+++ b/inc/SerialManager.h
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QtSerialPort/QSerialPort>
 #include <QtSerialPort/QSerialPortInfo>
+#include <QDebug>
 
 #include <functional>
 

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -80,12 +80,36 @@ MainWindow::MainWindow(QWidget *parent)
     m_receiveView = new QTextEdit;
     m_receiveView->setReadOnly(true);
     m_receiveView->setMinimumSize(470, 310);
+    m_receiveView->setContextMenuPolicy(Qt::CustomContextMenu);
     QPalette receivePalette = m_receiveView->palette();
     receivePalette.setColor(QPalette::Base, Qt::white);
     receivePalette.setColor(QPalette::Text, Qt::black);
     m_receiveView->setPalette(receivePalette);
     receiveLayout->addWidget(m_receiveView);
     topRow->addWidget(receiveGroup, 1);
+    connect(m_receiveView, &QWidget::customContextMenuRequested, this, [this](const QPoint &pos) {
+        QMenu menu(this);
+    
+        QAction *copyAct = menu.addAction("Copy");
+        copyAct->setShortcut(QKeySequence::Copy);
+    
+        QAction *selectAllAct = menu.addAction("Select All");
+        selectAllAct->setShortcut(QKeySequence::SelectAll);
+    
+        menu.addSeparator();
+    
+        QAction *clearAct = menu.addAction("Clear");
+    
+        QAction *selected = menu.exec(m_receiveView->mapToGlobal(pos));
+    
+        if (selected == copyAct) {
+            m_receiveView->copy();
+        } else if (selected == selectAllAct) {
+            m_receiveView->selectAll();
+        } else if (selected == clearAct) {
+            m_receiveView->clear();
+        }
+    });
 
     topRow->addWidget(createSerialPanel());
     serialLayout->addLayout(topRow, 1);
@@ -308,7 +332,6 @@ QGroupBox *MainWindow::createSendRow(const QString &placeholder)
             appendLogMessage(QString("TX failed | HEX=%1 | data=%2")
                 .arg(hexCheck->isChecked() ? "true" : "false")
                 .arg(visible));
-            qDebug() << "TX failed" << "HEX=" << hexCheck->isChecked() << "data=" << rawText;
             return;
         }
     
@@ -316,7 +339,6 @@ QGroupBox *MainWindow::createSendRow(const QString &placeholder)
             .arg(written)
             .arg(hexCheck->isChecked() ? "true" : "false")
             .arg(visible));
-        qDebug() << "TX written=" << written << "HEX=" << hexCheck->isChecked() << "data=" << rawText;
     });
 
     return row;

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -160,6 +160,7 @@ QWidget *MainWindow::createSerialPanel()
         "460800",
         "921600"
     }, m_baudCombo);
+    m_baudCombo->setCurrentText("9600");
     addLabeledCombo("Data size", {"8", "7", "6", "5"}, m_dataBitsCombo);
     addLabeledCombo("Parity", {"none", "even", "odd", "mark", "space"}, m_parityCombo);
     addLabeledCombo("Handshake", {"OFF", "RTS/CTS", "XON/XOFF"}, m_handshakeCombo);
@@ -290,12 +291,32 @@ QGroupBox *MainWindow::createSendRow(const QString &placeholder)
     layout->addWidget(sendButton);
 
     connect(sendButton, &QPushButton::clicked, this, [this, lineEdit, hexCheck](){
-        QString text = lineEdit->text() + "\n";
+        const QString rawText = lineEdit->text();
+        qint64 written = -1;
+    
         if (hexCheck->isChecked()) {
-            this->m_serial.sendHex(text);
+            written = this->m_serial.sendHex(rawText);
         } else {
-            this->m_serial.sendText(text);
+            written = this->m_serial.sendText(rawText + "\n");
         }
+    
+        QString visible = rawText;
+        visible.replace("\r", "\\r");
+        visible.replace("\n", "\\n");
+    
+        if (written < 0) {
+            appendLogMessage(QString("TX failed | HEX=%1 | data=%2")
+                .arg(hexCheck->isChecked() ? "true" : "false")
+                .arg(visible));
+            qDebug() << "TX failed" << "HEX=" << hexCheck->isChecked() << "data=" << rawText;
+            return;
+        }
+    
+        appendLogMessage(QString("TX %1 bytes | HEX=%2 | data=%3")
+            .arg(written)
+            .arg(hexCheck->isChecked() ? "true" : "false")
+            .arg(visible));
+        qDebug() << "TX written=" << written << "HEX=" << hexCheck->isChecked() << "data=" << rawText;
     });
 
     return row;

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -19,6 +19,7 @@
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QWidget>
 #include <QDebug>
+#include <QMenu>
 
 #include "SerialManager.h"
 #include "AppSettings.h"


### PR DESCRIPTION
This pull request introduces several usability improvements and logging enhancements to the application's main window, focusing on the serial communication interface. The most significant changes are the addition of a custom context menu for the receive view, improved feedback and logging for send operations, and setting a default baud rate for serial connections.

**User Interface Enhancements:**

* Added a custom context menu to the `m_receiveView` (`QTextEdit`) with "Copy", "Select All", and "Clear" actions to improve user interaction with received serial data.
* Set the default baud rate in the serial panel to "9600" for a better out-of-the-box experience.

**Logging and Feedback Improvements:**

* Enhanced the send row logic to:
  - Log the number of bytes sent and whether the data was sent as hex or text.
  - Log failures when sending data, providing clear feedback in the UI.
  - Make log messages more readable by escaping newline and carriage return characters in the displayed data.

**Codebase Maintenance:**

* Added missing includes for `QDebug` and `QMenu` in header files to support new functionality and debugging. [[1]](diffhunk://#diff-49e75ba8ba412c9cde6ef27323ac0366526af99fbb495bb18c20dd472bc5ccd2R11) [[2]](diffhunk://#diff-e01217d18beda72241917d982361a44a9496a24e05e75d06fdf2da3d74cec06cR22)